### PR TITLE
add redlink=1 to Create Page link (mirrors MediaWiki handling)

### DIFF
--- a/appid.php
+++ b/appid.php
@@ -76,7 +76,7 @@ if ( count( $results ) == 1 )
 				if ( count( $results ) != 0 )
 				{
 					print '<p>No page for ' . $results['name'] . ' exists, would you like to create it?</p>';
-					print '<a href="//pcgamingwiki.com/w/index.php?title=' . $results['name'] . '&amp;action=edit"><div class="create-page-button">Create Page</div></a>';
+					print '<a href="//pcgamingwiki.com/w/index.php?title=' . $results['name'] . '&amp;action=edit&amp;redlink=1"><div class="create-page-button">Create Page</div></a>';
 				}
 				else
 				{

--- a/gog.php
+++ b/gog.php
@@ -93,7 +93,7 @@ if ( count( $results ) == 1 )
 			{
 				$title = $_GET['title'];
 				print '<p>No page for ' . $title . ' exists, would you like to create it?</p>';
-				print '<a href="http://pcgamingwiki.com/w/index.php?title=' . $title . '&amp;action=edit"><div class="create-page-button">Create Page</div></a>';
+				print '<a href="http://pcgamingwiki.com/w/index.php?title=' . $title . '&amp;action=edit&amp;redlink=1"><div class="create-page-button">Create Page</div></a>';
 			}
 			else if ( count( $results ) > 1 )
 			{


### PR DESCRIPTION
Adding `redlink=1`  ensures links are handled identically to normal MediaWiki redlinks. In situations where the page exists but was not returned (due to caching or other delays) the visitor is seamlessly redirected to the rendered page rather than opening it for editing.